### PR TITLE
Fix support for popups

### DIFF
--- a/Source/WebKit2/PlatformNix.cmake
+++ b/Source/WebKit2/PlatformNix.cmake
@@ -23,6 +23,7 @@ list(APPEND WebKit2_SOURCES
     Shared/nix/NativeWebGestureEventNix.cpp
     Shared/nix/NativeWebTouchEventNix.cpp
     Shared/nix/WebEventFactoryNix.cpp
+
     Shared/efl/ProcessExecutablePathEfl.cpp
 
     UIProcess/API/C/CoordinatedGraphics/WKView.cpp
@@ -39,6 +40,7 @@ list(APPEND WebKit2_SOURCES
     UIProcess/nix/WebContextNix.cpp
     UIProcess/nix/WebInspectorProxyNix.cpp
     UIProcess/nix/WebPageProxyNix.cpp
+    UIProcess/nix/WebPopupMenuListenerNix.cpp
     UIProcess/efl/WebPreferencesEfl.cpp
 
     UIProcess/Launcher/efl/ProcessLauncherEfl.cpp

--- a/Source/WebKit2/UIProcess/nix/WebPopupMenuListenerNix.cpp
+++ b/Source/WebKit2/UIProcess/nix/WebPopupMenuListenerNix.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2012 Samsung Electronics
+ * Copyright (C) 2012-2013 Nokia Corporation and/or its subsidiary(-ies).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebPopupMenuListenerNix.h"
+
+namespace WebKit {
+
+WebPopupMenuListenerNix::WebPopupMenuListenerNix(WebPopupMenuProxy::Client* client)
+    : WebPopupMenuProxy(client)
+{
+}
+
+void WebPopupMenuListenerNix::valueChanged(int newSelectedIndex)
+{
+    if (!m_client)
+        return;
+
+    m_client->valueChangedForPopupMenu(this, newSelectedIndex);
+    invalidate();
+}
+
+} // namespace WebKit

--- a/Source/WebKit2/UIProcess/nix/WebPopupMenuListenerNix.h
+++ b/Source/WebKit2/UIProcess/nix/WebPopupMenuListenerNix.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2012 Samsung Electronics
+ * Copyright (C) 2012-2013 Nokia Corporation and/or its subsidiary(-ies).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef WebPopupMenuListenerNix_h
+#define WebPopupMenuListenerNix_h
+
+#include "WebPopupMenuProxy.h"
+
+namespace WebKit {
+
+class WebPopupMenuListenerNix : public WebPopupMenuProxy {
+public:
+    static PassRefPtr<WebPopupMenuListenerNix> create(WebPopupMenuProxy::Client* client)
+    {
+        return adoptRef(new WebPopupMenuListenerNix(client));
+    }
+
+    void valueChanged(int newSelectedIndex);
+
+private:
+    WebPopupMenuListenerNix(WebPopupMenuProxy::Client*);
+};
+
+} // namespace WebKit
+
+#endif // WebPopupMenuListenerNix_h

--- a/Source/WebKit2/UIProcess/nix/WebViewNix.cpp
+++ b/Source/WebKit2/UIProcess/nix/WebViewNix.cpp
@@ -35,6 +35,7 @@
 #include "NativeWebWheelEvent.h"
 #include "WebContext.h"
 #include "WebPageGroup.h"
+#include "WebPopupMenuListenerNix.h"
 #include "WebPreferences.h"
 #include <WebCore/CoordinatedGraphicsScene.h>
 #include <WebCore/TextureMapperGL.h>
@@ -154,6 +155,12 @@ void WebViewNix::updateTextInputState()
     const IntRect& editorRect = editor.editorRect;
     m_viewClientNix.updateTextInputState(this, editor.selectedText, editor.surroundingText, editor.inputMethodHints,
                                          editor.isContentEditable, editor.cursorRect, editor.editorRect);
+}
+
+
+PassRefPtr<WebPopupMenuProxy> WebViewNix::createPopupMenuProxy(WebPageProxy* page)
+{
+    return WebPopupMenuListenerNix::create(page);
 }
 
 } // namespace WebKit

--- a/Source/WebKit2/UIProcess/nix/WebViewNix.h
+++ b/Source/WebKit2/UIProcess/nix/WebViewNix.h
@@ -73,6 +73,7 @@ protected:
     virtual void didRelaunchProcess() OVERRIDE;
     virtual void pageTransitionViewportReady() OVERRIDE;
     virtual PassRefPtr<WebContextMenuProxy> createContextMenuProxy(WebPageProxy*) OVERRIDE { return m_activeContextMenu; }
+    virtual PassRefPtr<WebPopupMenuProxy> createPopupMenuProxy(WebPageProxy*) OVERRIDE;
 
 private:
     WebViewNix(WebContext* context, WebPageGroup* pageGroup);


### PR DESCRIPTION
A WebPopupMenuProxy needs to be created, otherwise WKPopup callbacks are not called.
Copied from the EFL implementation.
