### PR TITLE
Fix the default cache directory.

### DIFF
--- a/Source/WebKit2/UIProcess/nix/WebContextNix.cpp
+++ b/Source/WebKit2/UIProcess/nix/WebContextNix.cpp
@@ -105,7 +105,7 @@ String WebContext::platformDefaultLocalStorageDirectory() const
 
 String WebContext::platformDefaultDiskCacheDirectory() const
 {
-    GOwnPtr<gchar> diskCacheDirectory(g_build_filename(g_get_user_cache_dir(), g_get_prgname(), NULL));
+    GOwnPtr<gchar> diskCacheDirectory(g_build_filename(g_get_user_cache_dir(), "webkitnix", "cache", NULL));
     return WebCore::filenameToString(diskCacheDirectory.get());
 }
 


### PR DESCRIPTION
Because of the `g_get_prgname` returning an empty string the cache directory was set to ~/.cache/.

This modification is in align with the other `platformDefault*` methods.
