### PR TITLE
Buildfix if NIX is built with libcurl

### DIFF
--- a/Source/WebKit2/UIProcess/nix/WebViewNix.cpp
+++ b/Source/WebKit2/UIProcess/nix/WebViewNix.cpp
@@ -41,6 +41,8 @@
 #include <WebCore/CoordinatedGraphicsScene.h>
 #include <WebCore/TextureMapperGL.h>
 
+#include <glib.h>
+
 using namespace WebCore;
 
 namespace WebKit {


### PR DESCRIPTION
When NIX is built with libcurl network backend then in some cases
the glib.h is not included. This is also such a case. Just added a
simple glib.h include to the file.
