### PR TITLE
Fix build with curl enabled.

### DIFF
--- a/Source/WebCore/platform/network/curl/DNSCurl.cpp
+++ b/Source/WebCore/platform/network/curl/DNSCurl.cpp
@@ -39,6 +39,7 @@ void prefetchDNS(const String& hostname)
 bool DNSResolveQueue::platformProxyIsEnabledInSystemPreferences()
 {
     notImplemented();
+    return false;
 }
 
 void DNSResolveQueue::platformResolve(const String& hostname)

--- a/Source/WebCore/platform/network/curl/ResourceHandleManager.cpp
+++ b/Source/WebCore/platform/network/curl/ResourceHandleManager.cpp
@@ -311,10 +311,9 @@ static size_t headerCallback(char* ptr, size_t size, size_t nmemb, void* data)
      */
     if (header == String("\r\n") || header == String("\n")) {
         CURL* h = d->m_handle;
-        CURLcode err;
 
         long httpCode = 0;
-        err = curl_easy_getinfo(h, CURLINFO_RESPONSE_CODE, &httpCode);
+        curl_easy_getinfo(h, CURLINFO_RESPONSE_CODE, &httpCode);
 
         if (isHttpInfo(httpCode)) {
             // Just return when receiving http info, e.g. HTTP/1.1 100 Continue.
@@ -323,11 +322,11 @@ static size_t headerCallback(char* ptr, size_t size, size_t nmemb, void* data)
         }
 
         double contentLength = 0;
-        err = curl_easy_getinfo(h, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &contentLength);
+        curl_easy_getinfo(h, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &contentLength);
         d->m_response.setExpectedContentLength(static_cast<long long int>(contentLength));
 
         const char* hdr;
-        err = curl_easy_getinfo(h, CURLINFO_EFFECTIVE_URL, &hdr);
+        curl_easy_getinfo(h, CURLINFO_EFFECTIVE_URL, &hdr);
         d->m_response.setURL(KURL(ParsedURLString, hdr));
 
         d->m_response.setHTTPStatusCode(httpCode);

--- a/Source/WebKit2/WebProcess/nix/WebProcessMainNix.cpp
+++ b/Source/WebKit2/WebProcess/nix/WebProcessMainNix.cpp
@@ -65,16 +65,16 @@ WK_EXPORT int WebProcessMainNix(int argc, char* argv[])
 
     RunLoop::initializeMainRunLoop();
 
+#ifdef WTF_USE_SOUP
     const char* httpProxy = getenv("http_proxy");
     if (httpProxy) {
         const char* noProxy = getenv("no_proxy");
-#ifdef WTF_USE_SOUP
         SoupSession* session = WebCore::ResourceHandle::defaultSession();
         SoupProxyURIResolver* resolverNix = soupProxyResolverWkNew(httpProxy, noProxy);
         soup_session_add_feature(session, SOUP_SESSION_FEATURE(resolverNix));
         g_object_unref(resolverNix);
-#endif
     }
+#endif
 
     int socket = atoi(argv[1]);
 


### PR DESCRIPTION
When building with curl enabled the build fails due to the fact that there are some unused variables. This is because the -Werror is also enabled.

Changes:
- Removed unused variable from ResourceHandleManager.
- Added return value in the DNSCurl.
- Moved the WTF_USE_SOUP ifdef to a better place to avoid unused variables warning.
